### PR TITLE
Updated ParaFrame demo to resolve WSL failed to parse error

### DIFF
--- a/demos/ParaFrame.ipynb
+++ b/demos/ParaFrame.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "forced-windows",
    "metadata": {},
    "outputs": [
@@ -157,7 +157,7 @@
     }
    ],
    "source": [
-    "%%sh\n",
+    "%%bash\n",
     "\n",
     "for a in {0..9}; do\n",
     "  mkdir -p \"data/a_$a\"\n",


### PR DESCRIPTION
##Summary:
Fixed the failed to parse error for WSL users in the ParaFrame demo in accordance with issue #7. 

##Details:
Changed %%sh to %%bash in the first cell of the demo. In WSL, using %%sh directs ubuntu to use /bin/dash, which is a minimal shell. Using %%bash directs ubuntu to use /bin/bash, allowing the user to use the normal bash features. This change allows the demo to run properly for both Mac and WSL users.

##Testing:
After making the change to ParaFrame.ipynb, we ran the corresponding cell and did not see the Failed to Parse error. 

##Additional Info:
While working on this error, I initially intended on making the change in my own development branch and merging that to main, however when initiating the pull request, I noticed that since I had run the demo on my own branch, it had changed all of the default outputs of the demo to be reflective of my own machine (ie noting the virtual environment that I used while running the demo). To avoid pulling these changes in main, I created an issue specific branch in which I made the change and did not run the script.

##Follow on:
We should devise a procedure/workflow for making changes to the demo file without affecting the outputs for future pull requests. 