### PR TITLE
Add workflow for publishing docs on github pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,39 @@
+# Workflow to publish the documentation website on github pages for tagged releases
+
+name: Documentation
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          
+      - name: Install sphinx
+        run: |
+          pip install sphinx
+
+      - name: Build docs
+        run: |
+          sphinx-build doc _build
+
+      - name: Upload artifacts
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "doc/_build/html"
+
+      - name: Deploy to GitHub pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        
+
+          
+          


### PR DESCRIPTION
Added a first pass at a workflow to publish Sphinx documentation on GitHub Pages for tagged releases.